### PR TITLE
Standardize file paths to use forward slashes

### DIFF
--- a/src/deploy.js
+++ b/src/deploy.js
@@ -104,6 +104,9 @@ export const handleFile = co.wrap(function *(filePath, cwd, filePrefix, client, 
       return;
     }
 
+    fileObject.base = fileObject.base.split('\\').join('/');
+    fileObject.path = fileObject.path.split('\\').join('/');
+
     const fileUploadStatus = yield upload(client, fileObject, s3Options, filePrefix, ext);
     console.log(fileUploadStatus);
   }


### PR DESCRIPTION
This will address deployment from Windows/backslash filesystems, converting all S3 object names to use forward slashes to properly represent nested directories.